### PR TITLE
fix displayed size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ endif
 
 $(OUTPUT_TARGET_HEX): $(OUTPUT_TARGET_ELF)
 	$(HOST_OBJCPY) -O ihex $^ $@
-	$(HOST_SIZE) $@
+	$(HOST_SIZE) $^
 
 $(OUTPUT_TARGET_BIN): $(OUTPUT_TARGET_ELF)
 	$(HOST_OBJCPY) -O binary $^ $@


### PR DESCRIPTION
L'outil HOST_SIZE a besoin du fichier elf et non hex. Sinon il considère toute la section TEXT comme étant de la RAM.