### PR TITLE
Problèmes avec le téléchargement de FreeRTOS

### DIFF
--- a/Operating_Systems/FreeRTOS/Kconfig
+++ b/Operating_Systems/FreeRTOS/Kconfig
@@ -37,6 +37,6 @@ config FREERTOS_VERSION_DOWNLOAD
 config FREERTOS_URL_DOWNLOAD
     depends on FREERTOS_DOWNLOAD
     string "FreeRTOS package to download"
-    default "http://sourceforge.net/projects/freertos/files/FreeRTOS/V7.5.3/FreeRTOSV$(CONFIG_FREERTOS_VERSION_DOWNLOAD).zip"
+    default "http://sourceforge.net/projects/freertos/files/FreeRTOS/V$(CONFIG_FREERTOS_VERSION_DOWNLOAD)/FreeRTOSV$(CONFIG_FREERTOS_VERSION_DOWNLOAD).zip"
     help
         TODO

--- a/Operating_Systems/FreeRTOS/freertos.mk
+++ b/Operating_Systems/FreeRTOS/freertos.mk
@@ -68,7 +68,7 @@ $(FREERTOS_TOP_PATH)/.extracted:$(ARCHIVE_FREERTOS_PATH)
 # Download requested files
 $(ARCHIVE_FREERTOS_PATH):
 	$(MKDIR_P) $(CONFIG_DOWNLOADS_DIR)
-	$(WGET) -O $@ $(CONFIG_FREERTOS_URL_DOWNLOAD)
+	$(WGET) -O $@ $(CONFIG_FREERTOS_URL_DOWNLOAD) || $(RM_RF) $@
 
 .PHONY: freertos-clean freertos-dirclean
 freertos-clean:


### PR DESCRIPTION
Petit patch qui corrige deux problèmes dans le téléchargement de freeRTOS:

 - en cas d'échec de téléchargement (404,...), wget laisse un fichier vide. Ce qui empeche makefile de retenter un téléchargement. Il fallait manuellement supprimer le fichier.
- L'adresse par défaut du téléchargement de freeRTOS avait une référence à V7.5.3