### PR TITLE
Fix freertos v8 cm4

### DIFF
--- a/Operating_Systems/FreeRTOS/include/FreeRTOSConfig.h
+++ b/Operating_Systems/FreeRTOS/include/FreeRTOSConfig.h
@@ -103,7 +103,7 @@
 
 #define configTICK_RATE_HZ				( ( portTickType ) CONFIG_FREERTOS_TICK_RATE_HZ )
 
-#define configMAX_PRIORITIES			( ( unsigned portBASE_TYPE ) CONFIG_FREERTOS_MAX_PRIORITIES )
+#define configMAX_PRIORITIES			( CONFIG_FREERTOS_MAX_PRIORITIES )
 
 #define configMINIMAL_STACK_SIZE		( ( unsigned short ) CONFIG_FREERTOS_MINIMAL_STACK_SIZE )
 

--- a/Operating_Systems/FreeRTOS/include/FreeRTOSConfig.h
+++ b/Operating_Systems/FreeRTOS/include/FreeRTOSConfig.h
@@ -101,7 +101,7 @@
 
 #define configCPU_CLOCK_HZ				( CONFIG_FREERTOS_CPU_CLOCK_HZ )	
 
-#define configTICK_RATE_HZ				( ( portTickType ) CONFIG_FREERTOS_TICK_RATE_HZ )
+#define configTICK_RATE_HZ				( ( TickType_t ) CONFIG_FREERTOS_TICK_RATE_HZ )
 
 #define configMAX_PRIORITIES			( CONFIG_FREERTOS_MAX_PRIORITIES )
 

--- a/Operating_Systems/FreeRTOS/include/FreeRTOSConfig.h
+++ b/Operating_Systems/FreeRTOS/include/FreeRTOSConfig.h
@@ -75,6 +75,8 @@
 
 #include <generated/autoconf.h>
 
+#include "projdefs.h" //needed to test FreeRTOS version
+
 /*-----------------------------------------------------------
  * Application specific definitions.
  *
@@ -101,7 +103,11 @@
 
 #define configCPU_CLOCK_HZ				( CONFIG_FREERTOS_CPU_CLOCK_HZ )	
 
+#ifndef pdMS_TO_TICKS //FREERTOS v7
+#define configTICK_RATE_HZ				( ( portTickType ) CONFIG_FREERTOS_TICK_RATE_HZ )
+#else //FREERTOS v8
 #define configTICK_RATE_HZ				( ( TickType_t ) CONFIG_FREERTOS_TICK_RATE_HZ )
+#endif
 
 #define configMAX_PRIORITIES			( CONFIG_FREERTOS_MAX_PRIORITIES )
 


### PR DESCRIPTION
Modification sur le fichier de FreeRTOS afin de gérer FreeRTOS v7 et FreeRTOS v8 en toute transparence.